### PR TITLE
Adopted more async logic for better parallel processing

### DIFF
--- a/chatlogic/main.py
+++ b/chatlogic/main.py
@@ -72,7 +72,7 @@ async def output_final_response(websocket: WebSocket, input_user_prompt, collect
     return None
 
 @app.websocket("/promptstreaming")
-async def run_prompt(websocket: WebSocket):    
+async def run_prompt(websocket: WebSocket):
     await websocket.accept()
     input_user_prompt = await get_relevant_prompt(websocket)
     if input_user_prompt is None:

--- a/chatlogic/prompts.toml
+++ b/chatlogic/prompts.toml
@@ -57,13 +57,13 @@ answer the teacher's original question below.
 text = '''
 You are part of a larger process of taking a teacher question and using an AI chatbot to look up relevant data in a school database and answer the question.
 The issue is that for the AI chatbot to look up data, it has to know who or what the teacher is referring to, and parse that into something that the chatbot can use to look up relevant data.
-Your job right now is to input the teacher prompt and build a structured query for the next AI chatbot to take and actually look up the data.
+Your job right now is to input the teacher prompt and build a structured object that contains identifiable student or staff data for the next AI chatbot to take and actually look up the data.
 The JSON object for each person or thing looks like this:
 "person_type":"student"
 or
 "person_type":"staff"
-or
-"person_type":"staff"
+
+If a name is given and you're unsure if it's a student or staff member, default to "person_type":"student"
 
 If the question is not really specifying anyone or anything specific, then you can respond with "none" as shown below.
 
@@ -453,7 +453,7 @@ text = '''
 Your job is to check the output of an AI Chatbot for number/data accuracy. 
 You will receive both a user prompt and an AI chatbot output which may comprise a GraphQL query.
 If the AI chatbot output accurately reflects the ID number or other user data that the user prompt gave, then respond with "Yes" (without quotes)
-If the AI chatbot output does not accurately reflect the ID number that the user prompt gave, then respond by redoing the query with the correct number or information.
+If the AI chatbot output does not accurately reflect the ID number that the user prompt gave, then respond with No.
 Your highest priority should be fixing an incorrect query that blatantly mis-copied basic information from the original user prompt.
 If the query accurately transcribes key data from the original prompt, then respond with "Yes".
 
@@ -493,6 +493,6 @@ query dailyAttendanceFindByDate {
                 }
 Response: No
 
-Here is the actual user prompt:
+Here is the actual user prompt and the AI-generated query:
 
 '''

--- a/chatlogic/src/client.py
+++ b/chatlogic/src/client.py
@@ -1,0 +1,44 @@
+from openai import OpenAI, AsyncOpenAI
+from src.config import Config
+
+class LLMClient:
+    def __init__(self, config = None, async_client = False):
+        self.config = config if config else Config()
+        self.client = self._get_client(async_client)
+    
+    def _get_client(self, async_client):
+        if async_client:
+            return AsyncOpenAI(
+                api_key=self.config.key,
+                base_url=self.config.url
+            )
+        return OpenAI(
+                api_key=self.config.key,
+                base_url=self.config.url
+            )
+    
+    
+    # unused code below
+    # async def send_prompt_async(self, prompt, system_prompt):
+    #     if self.async_client:
+    #         return await self.client.chat.completions.create(
+    #             model=self.model,
+    #             messages=[
+    #                 {"role": "system", "content": system_prompt},
+    #                 {"role": "user", "content": prompt},
+    #             ],
+    #         )
+    #     else:
+    #         raise NotImplementedError("Client has been initialized without async. Use send_prompt instead.")
+
+    # def send_prompt(self, prompt, system_prompt):
+    #     if not self.async_client:
+    #         return self.client.chat.completions.create(
+    #             model=self.model,
+    #             messages=[
+    #                 {"role": "system", "content": system_prompt},
+    #                 {"role": "user", "content": prompt},
+    #             ],
+    #         )
+    #     else:
+    #         raise NotImplementedError("Client has been initialized as Async. Use send_prompt_async instead.")

--- a/chatlogic/src/config.py
+++ b/chatlogic/src/config.py
@@ -1,6 +1,5 @@
 import tomllib, pathlib, os
 from dotenv import load_dotenv
-from openai import OpenAI, AsyncOpenAI
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
@@ -49,46 +48,3 @@ class Config:
             self.selected_model = model_name
         else:
             raise ValueError(f"Model {model_name} not found in configuration.")
-
-class LLMClient:
-    def __init__(self, async_client = False, config = Config()):
-        self.config = config
-        self.client = self._get_client(type_async=async_client,config=config)
-        self.model = config.selected_model
-    
-    def _get_client(self, config, type_async):
-        if type_async:
-            client = AsyncOpenAI(
-                api_key=config.key,
-                base_url=config.url
-            )
-        else: 
-            client = OpenAI(
-                api_key=config.key,
-                base_url=config.url
-            )
-        return client
-    
-    async def send_prompt_async(self, prompt, system_prompt):
-        if self.client:
-            return await self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt},
-                ],
-            )
-        else:
-            raise NotImplementedError("Async client not initialized. Please initialize with async_client=True.")
-
-    def send_prompt_sync(self, prompt, system_prompt):
-        if not self.client:
-            return self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt},
-                ],
-            )
-        else:
-            raise NotImplementedError("Synchronous method called on an async client. Use send_prompt_async instead.")

--- a/chatlogic/src/config.py
+++ b/chatlogic/src/config.py
@@ -1,6 +1,6 @@
 import tomllib, pathlib, os
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import OpenAI, AsyncOpenAI
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
@@ -51,19 +51,44 @@ class Config:
             raise ValueError(f"Model {model_name} not found in configuration.")
 
 class LLMClient:
-    def __init__(self, config = Config()):
+    def __init__(self, async_client = False, config = Config()):
         self.config = config
-        self.client = OpenAI(
-        api_key=config.key,
-        base_url=config.url
-        )
+        self.client = self._get_client(type_async=async_client,config=config)
         self.model = config.selected_model
-        
-    def send_prompt(self, prompt, system_prompt):
-        return self.client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": prompt},
-            ],
-        )
+    
+    def _get_client(self, config, type_async):
+        if type_async:
+            client = AsyncOpenAI(
+                api_key=config.key,
+                base_url=config.url
+            )
+        else: 
+            client = OpenAI(
+                api_key=config.key,
+                base_url=config.url
+            )
+        return client
+    
+    async def send_prompt_async(self, prompt, system_prompt):
+        if self.client:
+            return await self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        else:
+            raise NotImplementedError("Async client not initialized. Please initialize with async_client=True.")
+
+    def send_prompt_sync(self, prompt, system_prompt):
+        if not self.client:
+            return self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        else:
+            raise NotImplementedError("Synchronous method called on an async client. Use send_prompt_async instead.")

--- a/chatlogic/src/graphql.py
+++ b/chatlogic/src/graphql.py
@@ -39,12 +39,14 @@ class GQLAgent:
         combined_fields = list(set(standard_fields + mandatory_fields))
         return combined_fields
     
-    def _fetch_fields(self, task_prompt, user_prompt) -> str:
+    async def _fetch_fields(self, task_prompt, user_prompt) -> str:
         task_engine = LLMPrompt(
             prompt=(task_prompt + user_prompt),
-            system_prompt=self.system_prompt
+            system_prompt=self.system_prompt,
+            async_client=True
             )
-        return extractContent(task_engine.send(json_mode=True))
+        response = await task_engine.send_async(json_mode=True)
+        return extractContent(response)
     
     def _generate_final_response(self, gql_query_response: Dict[str,Any]) -> str:
         final_response = ("The teacher asked the question " 
@@ -53,11 +55,14 @@ class GQLAgent:
         + str(gql_query_response))
         return final_response
     
-    def _llm_check_query_logic(self, stringquery):
+    async def _llm_check_query_logic(self, stringquery):
+        check_query_prompt = self.prompts_file.get('check_query_prompt').get('text')
+        combined_prompt = check_query_prompt + self.user_prompt + '\n' + stringquery
         check_query_engine = LLMPrompt(system_prompt=self.system_prompt,
-                  prompt=self.prompts_file.get('check_query_prompt').get('text'),
+                  prompt=combined_prompt,
+                  async_client=True
                   )
-        response = check_query_engine.send()
+        response = await check_query_engine.send_async()
         response_return = extractContent(response)
         print(f"## IS THE GRAPHQL QUERY {stringquery} LOGICALLY SOUND?")
         print(f"## RESPONSE: {response_return}")
@@ -68,15 +73,16 @@ class GQLAgent:
         attempts = 0
         while attempts <= max_retries:
             try:
-                gql_raw_query_builder = self._fetch_fields(task_prompt=self._get_task_prompt(), user_prompt=self.user_prompt)
+                gql_raw_query_builder = await self._fetch_fields(task_prompt=self._get_task_prompt(), user_prompt=self.user_prompt)
                 validated_gql_query_args = GQLQueryModel.model_validate_json(gql_raw_query_builder)                
                 stringquery = self._generate_complete_gql_query(validated_gql_query_args)
-                is_logical_query = self._llm_check_query_logic(stringquery)
-                if is_logical_query == "No":
-                    print(f"## GQL checker did not like the stringquery {stringquery}! Making it redo.")
-                    self.user_prompt += "\n GraphQL query did not accurately transcribe the data from the context. Please adjust the query."
-                    attempts += 1
-                    continue
+                # Performance issues with this code
+                # is_logical_query = await self._llm_check_query_logic(stringquery)
+                # if is_logical_query.startswith("No"):
+                #     print(f"## GQL checker did not like the stringquery {stringquery}! Making it redo.")
+                #     self.user_prompt += "\n GraphQL query did not accurately transcribe the data from the context. Please adjust the query."
+                #     attempts += 1
+                #     continue
                 
                 query_phrase = gql(stringquery)
                 gql_query_response = await self.gqlclient.execute_async(query_phrase)
@@ -147,6 +153,5 @@ class GQLAgent:
         print("raw generated gql query is " + str(query))
         return query
 
-    
     def _get_task_prompt(self):
         return self.prompts_file.get(self.task).get('text')

--- a/chatlogic/src/orchestrator.py
+++ b/chatlogic/src/orchestrator.py
@@ -78,6 +78,7 @@ class Orchestrator:
             )
         return extractContent(id_summary_engine.send())
     
+    ## I WANT THIS TO BE ASYNC BECAUSE I WANT THE self.collected_data.append TO BE HAPPENING SIMULTANEOUSLY FOR EACH api_call
     async def _handle_call(self, api_call:ApiDecision):
         if api_call.api in ["none", "inaccessible"]:
             self.collected_data.append(api_call.reason)
@@ -117,6 +118,7 @@ class Orchestrator:
         
         print("##PROMPTING FOR APIS##")
         api_task_list = self._prompt_for_apis()
+        ## IT IS CRITICAL THAT EACH OF THE API_CALL things happens async. There is no required order of operations. 
         for api_call in api_task_list:
             print(f"## NOW CALLING {api_call.api} API")
             print(f"## QUERY: {api_call.query} API")

--- a/chatlogic/src/prompt.py
+++ b/chatlogic/src/prompt.py
@@ -1,7 +1,6 @@
 from fastapi import HTTPException
 from openai import APIConnectionError, APIError, APIResponseValidationError, APIStatusError, APITimeoutError, BadRequestError, ConflictError, InternalServerError, NotFoundError, PermissionDeniedError, RateLimitError, AuthenticationError, UnprocessableEntityError
 from pydantic import BaseModel
-from src.config import Config
 from src.client import LLMClient
 
 class PromptInput(BaseModel):

--- a/chatlogic/src/prompt.py
+++ b/chatlogic/src/prompt.py
@@ -1,7 +1,8 @@
 from fastapi import HTTPException
 from openai import APIConnectionError, APIError, APIResponseValidationError, APIStatusError, APITimeoutError, BadRequestError, ConflictError, InternalServerError, NotFoundError, PermissionDeniedError, RateLimitError, AuthenticationError, UnprocessableEntityError
 from pydantic import BaseModel
-from src.config import LLMClient
+from src.config import Config
+from src.client import LLMClient
 
 class PromptInput(BaseModel):
     prompt: str
@@ -32,9 +33,10 @@ exception_mappings = {
 }
 
 class LLMPrompt:
-    def __init__(self, prompt, system_prompt, client=LLMClient()):
-        self.client = client
-        self.model = client.model
+    def __init__(self, prompt, system_prompt, config=None, async_client=False):
+        self.client = LLMClient(async_client=async_client, config=config)
+        self.async_client = async_client
+        self.model = self.client.config.selected_model
         self.prompt = prompt
         self.system_prompt = system_prompt
         self.response = None
@@ -45,57 +47,76 @@ class LLMPrompt:
                     {"role": "user", "content": self.prompt},
                 ]
     
-    def getContent(self):
+    def getContent(self) -> str:
         return self.response.choices[0].message.content if self.response.choices else "No response"
-
-    def send(self, json_mode=False, stream=False, max_tokens=1024):
+    
+    def _request_arg_builder(self, json_mode, stream, max_tokens):
         request_args = {
             "model": self.model,
             "messages": self.messages,
-        "max_tokens": max_tokens
-        }
+            "max_tokens": max_tokens
+            }
         if json_mode:
             request_args["response_format"] = {"type": "json_object"}
         if stream:
             request_args["stream"] = True
+        return request_args
+    
+    def _handle_request_exception(self, e):
+        status_code, detail_msg = exception_mappings.get(type(e), (500, "An unexpected error occurred."))
+        detail = f"{detail_msg} {str(e)}"
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    async def send_async(self, json_mode=False, stream=False, max_tokens=1024):
+        if not self.async_client:
+            raise ValueError("Initialized non async OpenAI client. Use send instead")
+        request_args = self._request_arg_builder(json_mode,stream,max_tokens)
+        try:
+            self.response = await self.client.client.chat.completions.create(**request_args)
+        except Exception as e:
+            self._handle_request_exception(e)
+        return self.response
+        
+    def send(self, json_mode=False, stream=False, max_tokens=1024):
+        if self.async_client:
+            raise ValueError("Initialized AsyncOpenAI client. Use send_async instead")
+        request_args = self._request_arg_builder(json_mode,stream,max_tokens)
         try:
             self.response = self.client.client.chat.completions.create(**request_args)
         except Exception as e:
-            status_code, detail_msg = exception_mappings.get(type(e), (500, "An unexpected error occurred."))
-            detail = f"{detail_msg} {str(e)}"
-            raise HTTPException(status_code=status_code, detail=detail) from e
+            self._handle_request_exception(e)
         return self.response
 
     # unused code below
-    def _print_verbose_output(self, start_time, end_time):
-        elapsed_time = end_time - start_time
-        token_count = self._get_token_count()
+    # def _print_verbose_output(self, start_time, end_time):
+    #     elapsed_time = end_time - start_time
+    #     token_count = self._get_token_count()
 
-        input_tokens, output_tokens, total_tokens = self._get_token_details()
-        cost = self._calculate_cost(input_tokens, output_tokens)
+    #     input_tokens, output_tokens, total_tokens = self._get_token_details()
+    #     cost = self._calculate_cost(input_tokens, output_tokens)
 
-        # print("Response:", self.response.choices[0].message.content)
-        print("Tokens used:", token_count)
-        print(f"Time elapsed: {elapsed_time:.2f} seconds")
-        print(f"Estimated Cost: ${cost}")
+    #     # print("Response:", self.response.choices[0].message.content)
+    #     print("Tokens used:", token_count)
+    #     print(f"Time elapsed: {elapsed_time:.2f} seconds")
+    #     print(f"Estimated Cost: ${cost}")
 
-    def _get_token_count(self):
-        if hasattr(self.response, 'usage') and hasattr(self.response.usage, 'total_tokens'):
-            return self.response.usage.total_tokens
-        return "Token count not available"
+    # def _get_token_count(self):
+    #     if hasattr(self.response, 'usage') and hasattr(self.response.usage, 'total_tokens'):
+    #         return self.response.usage.total_tokens
+    #     return "Token count not available"
 
-    def _get_token_details(self):
-        if hasattr(self.response, 'usage'):
-            input_tokens = self.response.usage.prompt_tokens
-            output_tokens = self.response.usage.completion_tokens
-            total_tokens = input_tokens + output_tokens
-            return input_tokens, output_tokens, total_tokens
-        return "Unavailable", "Unavailable", "Unavailable"
+    # def _get_token_details(self):
+    #     if hasattr(self.response, 'usage'):
+    #         input_tokens = self.response.usage.prompt_tokens
+    #         output_tokens = self.response.usage.completion_tokens
+    #         total_tokens = input_tokens + output_tokens
+    #         return input_tokens, output_tokens, total_tokens
+    #     return "Unavailable", "Unavailable", "Unavailable"
 
-    def _calculate_cost(self, input_tokens, output_tokens):
-        input_token_cost = 0.0005 / 1000  # Cost per input token
-        output_token_cost = 0.0015 / 1000  # Cost per output token
-        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
-            return round((input_tokens * input_token_cost) + (output_tokens * output_token_cost), 5)
-        return "Cost calculation not available"
+    # def _calculate_cost(self, input_tokens, output_tokens):
+    #     input_token_cost = 0.0005 / 1000  # Cost per input token
+    #     output_token_cost = 0.0015 / 1000  # Cost per output token
+    #     if isinstance(input_tokens, int) and isinstance(output_tokens, int):
+    #         return round((input_tokens * input_token_cost) + (output_tokens * output_token_cost), 5)
+    #     return "Cost calculation not available"
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,6 @@ services:
       - "5173:5173"
     env_file:
       - .env
-    environment:
-      - VITE_CHATLOGIC_BASE_URL=http://chatlogic:8000
     init: true
     stop_grace_period: 1s
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - "5173:5173"
     env_file:
       - .env
+    environment:
+      - VITE_CHATLOGIC_BASE_URL=http://chatlogic:8000
     init: true
     stop_grace_period: 1s
     networks:


### PR DESCRIPTION
Where part of the program generates a list of API tasks, it is important to run them in parallel to save time.

In `chatlogic/src/orchestrator.py` you can see where each `_handle_call` which makes a gql query will run in sequence, thus consuming a lot of time if there are many tasks to perform. 
```python
api_task_list = self._prompt_for_apis()
for api_call in api_task_list:
    await self._handle_call(api_call)
```

This PR implements new `LLMClient` and `LLMPrompt` constructors that allows you to select async as a method, which will make it instantiate the `AsyncOpenAI` class. This combined with the use of `async` in all potentially blocking LLM prompt calls, and the use of this updated `asyncio` code has increased the execution time:

```python
api_task_list = await self._prompt_for_apis()
await asyncio.gather(*(self._handle_call(api_call) for api_call in api_task_list))
```

These `api_call` will now operate in parallel. There is still an issue with potentially catching the `TransportAlreadyConnected` so more work will have to be done to implement gql over Websockets on the Spring server. 

**Performance benchmark**

This is not comprehensive but I ran 10 manual tests both before and after this PR.

* Sync methods, sequential tasks: **10.79 seconds**

 * Async methods, asyncio.gather: **8.863 seconds**

This is an 18% decrease in average processing time, and will be even more dramatic as the queries become more complex and teachers ask general questions that require looking up data in 5+ APIs.
